### PR TITLE
feat: Add version subcommand that can tell the current build version

### DIFF
--- a/cmd/dagu.go
+++ b/cmd/dagu.go
@@ -47,7 +47,7 @@ func makeApp() *cli.App {
 	return &cli.App{
 		Name:      "Dagu",
 		Usage:     "Self-contained, easy-to-use workflow engine for smaller use cases",
-		UsageText: "dagu [options] <start|status|stop|retry|dry|server> [args]",
+		UsageText: "dagu [options] <start|status|stop|retry|dry|server|version> [args]",
 		Commands: []*cli.Command{
 			newStartCommand(),
 			newStatusCommand(),
@@ -55,6 +55,7 @@ func makeApp() *cli.App {
 			newRetryCommand(),
 			newDryCommand(),
 			newServerCommand(),
+			newVersionCommand(),
 		},
 	}
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+	"github.com/yohamta/dagu/internal/constants"
+)
+
+func newVersionCommand() *cli.Command {
+	return &cli.Command{
+		Name: "version",
+		Usage: "dagu version",
+		Action: func(c *cli.Context) error {
+			if constants.Version != "" {
+				fmt.Println(constants.Version)
+				return nil
+			}
+			return fmt.Errorf("failed to get version")
+		},
+	}
+}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"testing"
+)
+
+func Test_versionCommand(t *testing.T) {
+	tests := []appTest{
+		{
+			args: []string{"", "version"}, errored: false,
+			exactOutput: "0.0.1\n",
+		},
+	}
+
+	for _, v := range tests {
+		app := makeApp()
+		runAppTestOutput(app, v, t)
+	}
+}


### PR DESCRIPTION
I added `version` subcommand to print version on stdout.