### PR TITLE
feat: Added retry interval sec config

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ steps:
       skipped: true                  # Continue to the next regardless the preconditions are met or not
     retryPolicy:                     # Retry policy for the step
       limit: 2                       # Retry up to 2 times when the step failed
+      intervalSec: 5                 # Interval time before retry
     repeatPolicy:                    # Repeat policy for the step
       repeat: true                   # Boolean whether to repeat this step
       intervalSec: 60                # Interval time to repeat the step in seconds

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -444,7 +444,8 @@ func buildStep(variables []string, def *stepDef) (*Step, error) {
 	}
 	if def.RetryPolicy != nil {
 		step.RetryPolicy = &RetryPolicy{
-			Limit: def.RetryPolicy.Limit,
+			Limit:    def.RetryPolicy.Limit,
+			Interval: time.Second * time.Duration(def.RetryPolicy.IntervalSec),
 		}
 	}
 	if def.RepeatPolicy != nil {

--- a/internal/config/definition.go
+++ b/internal/config/definition.go
@@ -60,7 +60,8 @@ type repeatPolicyDef struct {
 }
 
 type retryPolicyDef struct {
-	Limit int
+	Limit       int
+	IntervalSec int
 }
 
 type smtpConfigDef struct {

--- a/internal/config/step.go
+++ b/internal/config/step.go
@@ -27,7 +27,8 @@ type Step struct {
 }
 
 type RetryPolicy struct {
-	Limit int
+	Limit    int
+	Interval time.Duration
 }
 
 type RepeatPolicy struct {

--- a/internal/scheduler/node.go
+++ b/internal/scheduler/node.go
@@ -75,6 +75,7 @@ type NodeState struct {
 	StartedAt  time.Time
 	FinishedAt time.Time
 	RetryCount int
+	RetriedAt  time.Time
 	DoneCount  int
 	Error      error
 }
@@ -146,6 +147,18 @@ func (n *Node) ReadRetryCount() int {
 	n.mu.RLock()
 	defer n.mu.RUnlock()
 	return n.RetryCount
+}
+
+func (n *Node) SetRetriedAt(retriedAt time.Time) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.RetriedAt = retriedAt
+}
+
+func (n *Node) ReadRetriedAt() time.Time {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	return n.RetriedAt
 }
 
 func (n *Node) ReadDoneCount() int {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -362,6 +362,9 @@ func handleError(node *Node) {
 		if node.RetryPolicy != nil && node.RetryPolicy.Limit > node.ReadRetryCount() {
 			log.Printf("%s failed but scheduled for retry", node.Name)
 			node.incRetryCount()
+			log.Printf("sleep %s for retry", node.RetryPolicy.Interval)
+			time.Sleep(node.RetryPolicy.Interval)
+			node.SetRetriedAt(time.Now())
 			node.updateStatus(NodeStatus_None)
 		} else {
 			node.updateStatus(NodeStatus_Error)


### PR DESCRIPTION
Added interval sec config to `retryPolicy`.

Example:
```yaml
steps:
  - name: task1
    command: main.py
    retryPolicy:
      limit: 2
      intervalSec: 5
```