### PR TITLE
feat: overwrite global setting with individual DAG config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,7 +27,7 @@ type Config struct {
 	LogDir            string
 	HandlerOn         HandlerOn
 	Steps             []*Step
-	MailOn            MailOn
+	MailOn            *MailOn
 	ErrorMail         *MailConfig
 	InfoMail          *MailConfig
 	Smtp              *SmtpConfig
@@ -174,8 +174,12 @@ func (b *builder) buildFromDefinition(def *configDefinition, globalConfig *Confi
 	}
 	c.Group = def.Group
 	c.Description = def.Description
-	c.MailOn.Failure = def.MailOn.Failure
-	c.MailOn.Success = def.MailOn.Success
+	if def.MailOn != nil {
+		c.MailOn = &MailOn{
+			Failure: def.MailOn.Failure,
+			Success: def.MailOn.Success,
+		}
+	}
 	c.Delay = time.Second * time.Duration(def.DelaySec)
 	c.Tags = parseTags(def.Tags)
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -304,3 +304,23 @@ func TestSockAddr(t *testing.T) {
 	cfg := &Config{ConfigPath: "testdata/testDag.yml"}
 	require.Regexp(t, `^/tmp/@dagu-testDag-[0-9a-f]+\.sock$`, cfg.SockAddr())
 }
+
+func TestOverwriteGlobalConfig(t *testing.T) {
+	l := &Loader{HomeDir: utils.MustGetUserHomeDir()}
+
+	cfg, err := l.Load(path.Join(testDir, "config_overwrite.yaml"), "")
+	require.NoError(t, err)
+
+	require.Equal(t, &MailOn{
+		Failure: false,
+		Success: false,
+	}, cfg.MailOn)
+
+	cfg, err = l.Load(path.Join(testDir, "config_no_overwrite.yaml"), "")
+	require.NoError(t, err)
+
+	require.Equal(t, &MailOn{
+		Failure: true,
+		Success: false,
+	}, cfg.MailOn)
+}

--- a/internal/config/definition.go
+++ b/internal/config/definition.go
@@ -10,7 +10,7 @@ type configDefinition struct {
 	HandlerOn         handerOnDef
 	Steps             []*stepDef
 	Smtp              smtpConfigDef
-	MailOn            mailOnDef
+	MailOn            *mailOnDef
 	ErrorMail         mailConfigDef
 	InfoMail          mailConfigDef
 	DelaySec          int

--- a/internal/models/status_test.go
+++ b/internal/models/status_test.go
@@ -39,7 +39,7 @@ func TestStatusSerialization(t *testing.T) {
 				RepeatPolicy: config.RepeatPolicy{}, Preconditions: []*config.Condition{},
 			},
 		},
-		MailOn:            config.MailOn{},
+		MailOn:            &config.MailOn{},
 		ErrorMail:         &config.MailConfig{},
 		InfoMail:          &config.MailConfig{},
 		Smtp:              &config.SmtpConfig{},

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -60,7 +60,7 @@ func (rp *Reporter) ReportSummary(status *models.Status, err error) {
 // SendMail is a function that sends a report mail.
 func (rp *Reporter) SendMail(cfg *config.Config, status *models.Status, err error) error {
 	if err != nil || status.Status == scheduler.SchedulerStatus_Error {
-		if cfg.MailOn.Failure {
+		if cfg.MailOn != nil && cfg.MailOn.Failure {
 			return rp.Mailer.SendMail(
 				cfg.ErrorMail.From,
 				[]string{cfg.ErrorMail.To},
@@ -69,7 +69,7 @@ func (rp *Reporter) SendMail(cfg *config.Config, status *models.Status, err erro
 			)
 		}
 	} else if status.Status == scheduler.SchedulerStatus_Success {
-		if cfg.MailOn.Success {
+		if cfg.MailOn != nil && cfg.MailOn.Success {
 			rp.Mailer.SendMail(
 				cfg.InfoMail.From,
 				[]string{cfg.InfoMail.To},

--- a/internal/reporter/reporter_test.go
+++ b/internal/reporter/reporter_test.go
@@ -34,7 +34,7 @@ func TestReporter(t *testing.T) {
 
 			cfg := &config.Config{
 				Name: "test DAG",
-				MailOn: config.MailOn{
+				MailOn: &config.MailOn{
 					Failure: true,
 				},
 				ErrorMail: &config.MailConfig{

--- a/tests/config/.dagu/config.yaml
+++ b/tests/config/.dagu/config.yaml
@@ -13,3 +13,5 @@ infoMail:
   to: "info@mail.com"
   prefix: "[INFO]"
 histRetentionDays: 7
+mailOn:
+  failure: true

--- a/tests/testdata/config_no_overwrite.yaml
+++ b/tests/testdata/config_no_overwrite.yaml
@@ -1,0 +1,3 @@
+steps:
+  - name: "1"
+    command: "true"

--- a/tests/testdata/config_overwrite.yaml
+++ b/tests/testdata/config_overwrite.yaml
@@ -1,0 +1,6 @@
+mailOn:
+  failure: false
+
+steps:
+  - name: "1"
+    command: "true"


### PR DESCRIPTION
Allow users to choose whether or not to send mail on failure with individual DAGs by overriding the `MailOn` settings.