### PR TITLE
internal/admin: no error on decode when there's unused keys

### DIFF
--- a/internal/admin/config_test.go
+++ b/internal/admin/config_test.go
@@ -20,6 +20,7 @@ basicAuthPassword: password
 logEncodingCharset: utf-8
 logDir: /var/log/dagu
 baseConfig: /dagu/config.yaml
+someInvalidKey: value
 navbarColor: red
 navbarTitle: Dagu test
 `

--- a/internal/admin/loader.go
+++ b/internal/admin/loader.go
@@ -86,9 +86,8 @@ func (cl *Loader) unmarshalData(data []byte) (map[string]interface{}, error) {
 func (cl *Loader) decode(cm map[string]interface{}) (*configDefinition, error) {
 	c := &configDefinition{}
 	md, _ := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-		ErrorUnused: true,
-		Result:      c,
-		TagName:     "",
+		Result:  c,
+		TagName: "",
 	})
 	err := md.Decode(cm)
 	return c, err


### PR DESCRIPTION
Unused key error in admin config should not stop jobs.