### PR TITLE
Add `host`, `port`, `dags` option to the `server` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ You can execute the example by pressing the `Start` button
 - `dagu retry --req=<request-id> <file>` - Re-runs the specified DAG run
 - `dagu stop <file>` - Stops the DAG execution by sending TERM signals
 - `dagu dry [--params=<params>] <file>` - Dry-runs the DAG
-- `dagu server` - Starts the web server for web UI
-- `dagu scheduler [--dags=<DAGs directory>]` - Starts the scheduler process
+- `dagu server [--host=<host>] [--port=<port>] [--dags=<path/to/the DAGs directory>]` - Starts the web server for web UI
+- `dagu scheduler [--dags=<path/to/the DAGs directory>]` - Starts the scheduler process
 - `dagu version` - Shows the current binary version
 
 The `--config=<config>` option is available to all commands. It allows to specify different Dagu configuration for the commands. Which enables you to manage multiple Dagu process in a single instance. See [Admin Configuration](#admin-configuration) for more details.

--- a/cmd/dagu.go
+++ b/cmd/dagu.go
@@ -48,6 +48,15 @@ func loadGlobalConfig(c *cli.Context) (cfg *admin.Config, err error) {
 	if err != nil {
 		return nil, fmt.Errorf("loading admin config failed: %w", err)
 	}
+	if dagsDir := c.String("dags"); dagsDir != "" {
+		cfg.DAGs = dagsDir
+	}
+	if port := c.String("port"); port != "" {
+		cfg.Port = port
+	}
+	if host := c.String("host"); host != "" {
+		cfg.Host = host
+	}
 	return cfg, err
 }
 

--- a/cmd/scheduler.go
+++ b/cmd/scheduler.go
@@ -26,10 +26,6 @@ func newSchedulerCommand() *cli.Command {
 			if err != nil {
 				return err
 			}
-			dagsDir := c.String("dags")
-			if dagsDir != "" {
-				cfg.DAGs = dagsDir
-			}
 			return startScheduler(cfg)
 		},
 	}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -12,7 +12,26 @@ func newServerCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "server",
 		Usage: "dagu server",
-		Flags: globalFlags,
+		Flags: append(globalFlags,
+			&cli.StringFlag{
+				Name:     "dags",
+				Usage:    "DAGs directory",
+				Value:    "",
+				Required: false,
+			},
+			&cli.StringFlag{
+				Name:     "port",
+				Usage:    "server port",
+				Value:    "",
+				Required: false,
+			},
+			&cli.StringFlag{
+				Name:     "host",
+				Usage:    "server host",
+				Value:    "",
+				Required: false,
+			},
+		),
 		Action: func(c *cli.Context) error {
 			cfg, err := loadGlobalConfig(c)
 			if err != nil {


### PR DESCRIPTION
example: `dagu server --host=10.0.100.101 --port=80 --dags=/home/var/dags`

Note: If those options are specified, the same field value in admin config will be ignored.