### PR TITLE
internal/dag: feat: Allow multiple start/stop schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,6 +525,21 @@ steps:
     command: job.sh
 ```
 
+You can also set multiple start/stop schedules. In the following example, the process will run at 0:00-12:00 and 5:00-17:00.
+
+```yaml
+schedule:
+  start:
+    - "0 0 * * *"
+    - "12 0 * * *"
+  stop:
+    - "5 0 * * *"
+    - "17 0 * * *"
+steps:
+  - name: some long-process
+    command: main.sh
+```
+
 ### Run Scheduler as a daemon
 
 The easiest way to make sure the process is always running on your system is to create the script below and execute it every minute using cron (you don't need `root` account in this way):

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -256,17 +256,32 @@ func (b *builder) buildSchedule(def *configDefinition, d *DAG) error {
 			if _, ok := k.(string); !ok {
 				return fmt.Errorf("schedule key must be a string")
 			}
-			key := k.(string)
-			switch key {
+			kk := k.(string)
+			switch kk {
 			case "start", "stop":
-				if _, ok := v.(string); !ok {
-					return fmt.Errorf("schedule value must be a string")
-				}
-				switch key {
-				case "start":
-					starts = append(starts, v.(string))
-				case "stop":
-					stops = append(stops, v.(string))
+				switch (v).(type) {
+				case string:
+					switch kk {
+					case "start":
+						starts = append(starts, v.(string))
+					case "stop":
+						stops = append(stops, v.(string))
+					}
+				case []interface{}:
+					for _, vv := range v.([]interface{}) {
+						if vvv, ok := vv.(string); ok {
+							switch kk {
+							case "start":
+								starts = append(starts, vvv)
+							case "stop":
+								stops = append(stops, vvv)
+							}
+						} else {
+							return fmt.Errorf("schedule must be a string or an array of strings")
+						}
+					}
+				default:
+					return fmt.Errorf("schedule must be a string or an array of strings")
 				}
 			default:
 				return fmt.Errorf("schedule key must be start or stop")

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -289,22 +289,24 @@ func TestSchedule(t *testing.T) {
 			Err: true,
 		},
 	} {
-		l := &Loader{}
-		m, err := l.unmarshalData([]byte(tc.Def))
-		require.NoError(t, err)
-
-		def, err := l.decode(m)
-		require.NoError(t, err)
-
-		b := &builder{}
-		d, err := b.buildFromDefinition(def, nil)
-
-		if tc.Err {
-			require.Error(t, err)
-		} else {
+		t.Run(tc.Name, func(t *testing.T) {
+			l := &Loader{}
+			m, err := l.unmarshalData([]byte(tc.Def))
 			require.NoError(t, err)
-			require.Equal(t, tc.Want, len(d.Schedule))
-		}
+
+			def, err := l.decode(m)
+			require.NoError(t, err)
+
+			b := &builder{}
+			d, err := b.buildFromDefinition(def, nil)
+
+			if tc.Err {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.Want, len(d.Schedule))
+			}
+		})
 	}
 }
 
@@ -340,6 +342,19 @@ func TestScheduleStop(t *testing.T) {
 `,
 			WantStart: 0,
 			WantStop:  1,
+		},
+		{
+			Name: "multiple schedule",
+			Def: `schedule:
+  start: 
+    - "0 1 * * *"
+    - "0 18 * * *"
+  stop:
+    - "0 2 * * *"
+    - "0 20 * * *"
+`,
+			WantStart: 2,
+			WantStop:  2,
 		},
 		{
 			Name: "invalid expression",


### PR DESCRIPTION
Example:
```yaml
schedule:
  start:
    - "0 0 * * *"
    - "12 0 * * *"
  stop:
    - "5 0 * * *"
    - "17 0 * * *"
```