### PR TITLE
Add `stderr` field to separate stderr output from the normal log file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ It runs <a href="https://en.wikipedia.org/wiki/Directed_acyclic_graph">DAGs (Dir
   - [Command Substitution](#command-substitution)
   - [Conditional Logic](#conditional-logic)
   - [Output](#output)
-  - [Redirection](#redirection)
+  - [Stdout and Stderr Redirection](#stdout-and-stderr-redirection)
   - [Lifecycle Hooks](#lifecycle-hooks)
   - [Repeating Task](#repeating-task)
   - [Calling Sub DAGs](#calling-sub-dags)
@@ -313,7 +313,7 @@ steps:
     output: FOO # will contain "foo"
 ```
 
-### Redirection
+### Stdout and Stderr Redirection
 
 `stdout` field can be used to write standard output to a file.
 
@@ -322,6 +322,15 @@ steps:
   - name: create a file
     command: "echo hello"
     stdout: "/tmp/hello" # the content will be "hello\n"
+```
+
+`stderr` field allows to redirect stderr to other file without writing to the normal log file.
+
+```yaml
+steps:
+  - name: output error file
+    command: "echo error message >&2"
+    stderr: "/tmp/error.txt"
 ```
 
 ### Lifecycle Hooks

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -505,6 +505,7 @@ func (b *builder) buildStep(variables []string, def *stepDef) (*Step, error) {
 	step.Command, step.Args = utils.SplitCommand(step.CmdWithArgs, false)
 	step.Script = def.Script
 	step.Stdout = b.expandEnv(def.Stdout)
+	step.Stderr = b.expandEnv(def.Stderr)
 	step.Output = def.Output
 	step.Dir = b.expandEnv(def.Dir)
 	step.Executor = def.Executor

--- a/internal/dag/definition.go
+++ b/internal/dag/definition.go
@@ -42,6 +42,7 @@ type stepDef struct {
 	Command       string
 	Script        string
 	Stdout        string
+	Stderr        string
 	Output        string
 	Depends       []string
 	ContinueOn    *continueOnDef

--- a/internal/dag/step.go
+++ b/internal/dag/step.go
@@ -19,6 +19,7 @@ type Step struct {
 	Command         string
 	Script          string
 	Stdout          string
+	Stderr          string
 	Output          string
 	Args            []string
 	Depends         []string

--- a/internal/scheduler/node_test.go
+++ b/internal/scheduler/node_test.go
@@ -119,8 +119,8 @@ echo Stdout message >&1
 echo Stderr message >&2
 			`,
 			Dir:             os.Getenv("HOME"),
-			Stdout:          "stdout.log",
-			Stderr:          "stderr.log",
+			Stdout:          "test-stderr-stdout.log",
+			Stderr:          "test-stderr-stderr.log",
 			OutputVariables: &sync.Map{},
 		},
 	}


### PR DESCRIPTION
Closes #312 

Example:
```yaml
steps:
  - name: output error file
    command: "echo error message >&2"
    stderr: "/tmp/error.txt"
```