### PR TITLE
fix start dag with params

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"strings"
 
 	"github.com/urfave/cli/v2"
 	"github.com/yohamta/dagu"
@@ -22,7 +23,7 @@ func newStartCommand() *cli.Command {
 			},
 		),
 		Action: func(c *cli.Context) error {
-			d, err := loadDAG(c, c.Args().Get(0), c.String("params"))
+			d, err := loadDAG(c, c.Args().Get(0), strings.Trim(c.String("params"), "\""))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
https://github.com/yohamta/dagu/issues/279#issuecomment-1237603177
Like shellworlds pasre string be quoted as raw-string.
```
dagu start --params "a b" demo.yaml

expect:
$1: a
$2: b

but:
$1: 'a b'
```
So we should trim the `"`.