### PR TITLE
fix bug

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -392,6 +392,8 @@ func (sc *Scheduler) isRunning(g *ExecutionGraph) bool {
 		switch node.ReadStatus() {
 		case NodeStatus_Running:
 			return true
+		case NodeStatus_None:
+			return true
 		}
 	}
 	return false


### PR DESCRIPTION
When a node is not be started, graph should be consided still running, however the function 'isRunning' will return true,so it should be a bug.