### PR TITLE
Update HTTP Executor to expand env

### DIFF
--- a/internal/executor/http.go
+++ b/internal/executor/http.go
@@ -64,7 +64,8 @@ func (e *HTTPExecutor) Run() error {
 func CreateHTTPExecutor(ctx context.Context, step *dag.Step) (Executor, error) {
 	var reqCfg HTTPConfig
 	if len(step.Script) > 0 {
-		if err := json.Unmarshal([]byte(step.Script), &reqCfg); err != nil {
+		script := os.ExpandEnv(step.Script)
+		if err := json.Unmarshal([]byte(script), &reqCfg); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
I would like to use environment variables in the HTTP script such as $API_KEY.

@Arvintian If you have any concerns with this change, please let me know.